### PR TITLE
Increase Slashing Window Prop

### DIFF
--- a/atlantic-2/proposals/03-09-2022-increase-vote-slashing-window.json
+++ b/atlantic-2/proposals/03-09-2022-increase-vote-slashing-window.json
@@ -1,0 +1,13 @@
+{
+    "title": "Change Signed Blocks Window to 12 hours",
+    "description": "Change slashing window to roughly 12 hours based on 0.4s block times",
+    "changes": [
+      {
+        "subspace": "slashing",
+        "key": "SignedBlocksWindow",
+        "value": "108000"
+      }
+    ],
+    "deposit": "10000000usei",
+    "is_expedited": true
+  }

--- a/sei-devnet-3/proposals/03-09-2022-increase-vote-slashing-window.json
+++ b/sei-devnet-3/proposals/03-09-2022-increase-vote-slashing-window.json
@@ -1,0 +1,13 @@
+{
+    "title": "Change Signed Blocks Window to 12 hours",
+    "description": "Change slashing window to roughly 12 hours based on 0.4s block times",
+    "changes": [
+      {
+        "subspace": "slashing",
+        "key": "SignedBlocksWindow",
+        "value": "108000"
+      }
+    ],
+    "deposit": "10000000usei",
+    "is_expedited": true
+  }


### PR DESCRIPTION
As discussed in the validators community call, our block times are really high right now and 10k slashing window is like an hour.


0.4ms block times:

60s / 0.4ms = 150 blocks per minute  * 60 mins * 12 hours = 108000 blocks per 12 hours

Ran locally:

Before
```
> seid q slashing params
downtime_jail_duration: 600s
min_signed_per_window: "0.050000000000000000"
signed_blocks_window: "10000"
slash_fraction_double_sign: "0.050000000000000000"
slash_fraction_downtime: "0.010000000000000000"```

AFter
```
> seid q slashing params
downtime_jail_duration: 600s
min_signed_per_window: "0.050000000000000000"
signed_blocks_window: "108000"
slash_fraction_double_sign: "0.050000000000000000"
slash_fraction_downtime: "0.010000000000000000"
```