### PR TITLE
Enforce Block max gas

### DIFF
--- a/atlantic-2/proposals/03-20-2023-max-block-gas.json
+++ b/atlantic-2/proposals/03-20-2023-max-block-gas.json
@@ -1,0 +1,16 @@
+{
+    "title": "Set Max Block Gas",
+    "description": "Set Max Block Gas",
+    "changes": [
+      {
+        "subspace": "baseapp",
+        "key": "BlockParams",
+        "value": {
+                "max_gas": "6000000",
+                "max_bytes": "22020096"
+        }
+      }
+    ],
+    "deposit": "10000000usei",
+    "is_expedited": true
+}

--- a/sei-devnet-3/proposals/03-20-2023-max-block-gas.json
+++ b/sei-devnet-3/proposals/03-20-2023-max-block-gas.json
@@ -1,0 +1,16 @@
+{
+    "title": "Set Max Block Gas",
+    "description": "Set Max Block Gas",
+    "changes": [
+      {
+        "subspace": "baseapp",
+        "key": "BlockParams",
+        "value": {
+                "max_gas": "6000000",
+                "max_bytes": "22020096"
+        }
+      }
+    ],
+    "deposit": "10000000usei",
+    "is_expedited": true
+}


### PR DESCRIPTION
Large contracts like vortex requires 5.x mil gas, so this is the min gas amount we need to set if we want to allow easier vortex upgrades 

Before
```
> seid q params subspace baseapp BlockParams
key: BlockParams
subspace: baseapp
value: '{"max_bytes":"22020096","max_gas":"-1"}'
```

After:
```
> seid q params subspace baseapp BlockParams
key: BlockParams
subspace: baseapp
value: '{"max_bytes":"22020096","max_gas":"6000000"}'
```