### PR TITLE
Add proposal to update unbonding time for atlantic-2

### DIFF
--- a/atlantic-2/proposals/06-26-2023-update-unbonding-time.json
+++ b/atlantic-2/proposals/06-26-2023-update-unbonding-time.json
@@ -1,0 +1,13 @@
+{
+    "title": "Update Unbonding Time",
+    "description": "Update UnbondingTime to 21 days",
+    "changes": [
+      {
+        "subspace": "staking",
+        "key": "UnbondingTime",
+        "value": "1814400000000000"
+      }
+    ],
+    "deposit": "10000000usei",
+    "is_expedited": true
+}

--- a/atlantic-2/proposals/06-26-2023-update-unbonding-time.json
+++ b/atlantic-2/proposals/06-26-2023-update-unbonding-time.json
@@ -9,5 +9,5 @@
       }
     ],
     "deposit": "10000000usei",
-    "is_expedited": true
+    "is_expedited": false
 }


### PR DESCRIPTION
Current value is: 259200000000000
We want to bump to: 1814400000000000
We need to update unbonding time back to 21 days, so that we can bump the trusting periods to 4-7 days