### PR TITLE
update oracle whitelist in atlantic-2

### DIFF
--- a/atlantic-2/proposals/08-10-2023-update-oracle-whitelist.json
+++ b/atlantic-2/proposals/08-10-2023-update-oracle-whitelist.json
@@ -1,0 +1,22 @@
+{
+    "title": "Change oracle whitelist",
+    "description": "Change oracle whitelist to add OSMO and USDT",
+    "changes": [
+      {
+        "subspace": "oracle",
+        "key": "Whitelist",
+        "value":
+        [
+            {"name":"uatom"},
+            {"name":"usei"},
+            {"name":"ueth"},
+            {"name":"ubtc"},
+            {"name":"factory/sei1jdppe6fnj2q7hjsepty5crxtrryzhuqsjrj95y/uust2"},
+            {"name": "uosmo"},
+            {"name": "uusdt"}
+        ]
+      }
+    ],
+    "deposit": "20sei",
+    "is_expedited": true
+  }


### PR DESCRIPTION
This updates the existing oracle whitelist in atlantic-2 to start supporting USDT and OSMO