### PR TITLE
Gov prop to remove uust2 from oracle whitelist

### DIFF
--- a/atlantic-2/proposals/2023-09-09-remove-uust2.json
+++ b/atlantic-2/proposals/2023-09-09-remove-uust2.json
@@ -18,4 +18,4 @@
     ],
     "deposit": "20sei",
     "is_expedited": true
-  }
+}

--- a/atlantic-2/proposals/2023-09-09-remove-uust2.json
+++ b/atlantic-2/proposals/2023-09-09-remove-uust2.json
@@ -1,0 +1,21 @@
+{
+    "title": "Remove factory/sei1jdppe6fnj2q7hjsepty5crxtrryzhuqsjrj95y/uust2 from atlantic-2 oracle whitelist",
+    "description": "Change oracle whitelist to remove factory/sei1jdppe6fnj2q7hjsepty5crxtrryzhuqsjrj95y/uust2",
+    "changes": [
+      {
+        "subspace": "oracle",
+        "key": "Whitelist",
+        "value":
+        [
+            {"name":"uatom"},
+            {"name":"usei"},
+            {"name":"ueth"},
+            {"name":"ubtc"},
+            {"name": "uosmo"},
+            {"name": "uusdt"}
+        ]
+      }
+    ],
+    "deposit": "20sei",
+    "is_expedited": true
+  }


### PR DESCRIPTION
This proposal for atlantic-2 will update the oracle whitelist to remove uust2

Current whitelist as of PR open:
```
  whitelist:
  - name: uatom
  - name: usei
  - name: ueth
  - name: ubtc
  - name: factory/sei1jdppe6fnj2q7hjsepty5crxtrryzhuqsjrj95y/uust2
  - name: uosmo
  - name: uusdt
```

proposed new whitelist after this gov prop:
```
  whitelist:
  - name: uatom
  - name: usei
  - name: ueth
  - name: ubtc
  - name: uosmo
  - name: uusdt
  ```