### PR TITLE
Remove only usdt2 from atlantic 2

### DIFF
--- a/atlantic-2/proposals/09-08-2023-remove-uustd-oracle-whitelist.json
+++ b/atlantic-2/proposals/09-08-2023-remove-uustd-oracle-whitelist.json
@@ -1,0 +1,24 @@
+{
+    "title": "Change oracle whitelist",
+    "description": "Change oracle whitelist to remove uust2",
+    "changes": [
+      {
+        "subspace": "oracle",
+        "key": "Whitelist",
+        "value":
+        [
+            { "name": "uatom" },
+            { "name": "usei" },
+            { "name": "ueth" },
+            { "name": "ubtc" },
+            { "name": "uosmo" },
+            { "name": "uusdt" }
+        ]
+      }
+    ],
+    "deposit": "20sei",
+    "is_expedited": true
+  }
+
+
+

--- a/atlantic-2/proposals/09-08-2023-remove-uustd-oracle-whitelist.json
+++ b/atlantic-2/proposals/09-08-2023-remove-uustd-oracle-whitelist.json
@@ -19,6 +19,3 @@
     "deposit": "20sei",
     "is_expedited": true
   }
-
-
-


### PR DESCRIPTION
- removes usdt2 from atlantic 2 
- this will let us make the config adjustments easier for validators

Today's values:
```
  whitelist:
  - name: uatom
  - name: usei
  - name: ueth
  - name: ubtc
  - name: factory/sei1jdppe6fnj2q7hjsepty5crxtrryzhuqsjrj95y/uust2
  - name: uosmo
  - name: uusdt
  ```
  
  New values:
```
  whitelist:
  - name: uatom
  - name: usei
  - name: ueth
  - name: ubtc
  - name: uosmo
  - name: uusdt
```