### PR TITLE
Add Sei SLO dashboard

### DIFF
--- a/sei-slo-dashboard/README.md
+++ b/sei-slo-dashboard/README.md
@@ -1,0 +1,64 @@
+# Sei SLO Grafana Dashboard
+
+This directory is a portable export of the Sei SLO dashboard. It is intended for operators who want to import the dashboard into their own Grafana and point it at their own Prometheus data.
+
+## Files
+
+- `sei_slo.json`: Grafana dashboard JSON.
+- `recording_rules.yaml`: Prometheus recording rules required by the dashboard SLO panels.
+
+## What Was Generalized
+
+The internal dashboard had a few repo-local values that should not be published as-is:
+
+- Grafana datasource UID `PBFA97CFB590B2093` was replaced with a dashboard variable named `datasource`.
+- Dashboard `id` was set to `null`, and dashboard `uid` was changed to `sei-slo`.
+- The default `chain_id` value `pacific-1` was removed. The dashboard now discovers chain IDs from `tendermint_consensus_latest_block_height`.
+- `chain_id="$chain_id"` selectors were changed to regex selectors so `All` and multi-chain selections work.
+- Hardcoded component labels are exposed as dashboard variables:
+  - `validator_component`, default `validators`
+  - `webapp_component`, default `webapp`
+- The public copy fixes the blocks-per-second 7-day panel to query `slo_blocks_per_second_7d`.
+
+## Import Steps
+
+1. Add `recording_rules.yaml` to your Prometheus rule files and reload Prometheus.
+2. Import `sei_slo.json` into Grafana.
+3. In the dashboard variables, choose your Prometheus datasource.
+4. Set `validator_component` and `webapp_component` if your Prometheus labels differ from the defaults.
+5. Select one or more `chain_id` values from the dashboard variable.
+
+## Required Prometheus Data
+
+The dashboard expects these raw metrics:
+
+- `tendermint_consensus_latest_block_height`
+- `tendermint_consensus_block_interval_seconds_bucket`
+- `tendermint_consensus_block_interval_seconds_count`
+- `sei_cosmos_throughput_transaction_count`
+- `sei_cosmos_throughput_message_count`
+- `cosmos_validators_missed_blocks`
+- `cosmos_params_signed_blocks_window`
+- `cosmos_validators_active`
+- `tendermint_consensus_propose_latency_bucket`
+- `cosmos_validators_jailed`
+
+The useful labels are `chain_id`, `component`, `moniker`, `address`, `pubkey_hash`, `proposer_address`, and `mode`. If your exporters use different label names or component values, update `recording_rules.yaml` and the matching Grafana variables.
+
+## Recording Rules
+
+The included rules generate the SLO series used by the dashboard:
+
+- `blocks_per_second`
+- `slo_consensus_block_speed_*`
+- `slo_blocks_per_second_*`
+- `block_miss_percentage_sliding_window`
+- `validator_propose_latency`
+- `slo_block_miss_*`
+- `slo_validator_proposal_latency_*`
+
+The price update table depends on `slo_price_update_*{chain_id,denom}` series. Those rules were not present next to the original dashboard in this repo, so they are not included here. If you do not publish price update SLO metrics, remove or hide the "Price Update SLO" panel.
+
+## Notes
+
+The Prometheus rules still assume the default component labels `validators` and `webapp`. If your metrics use different values, replace those strings in `recording_rules.yaml` before loading the rules.

--- a/sei-slo-dashboard/README.md
+++ b/sei-slo-dashboard/README.md
@@ -7,19 +7,6 @@ This directory is a portable export of the Sei SLO dashboard. It is intended for
 - `sei_slo.json`: Grafana dashboard JSON.
 - `recording_rules.yaml`: Prometheus recording rules required by the dashboard SLO panels.
 
-## What Was Generalized
-
-The internal dashboard had a few repo-local values that should not be published as-is:
-
-- Grafana datasource UID `PBFA97CFB590B2093` was replaced with a dashboard variable named `datasource`.
-- Dashboard `id` was set to `null`, and dashboard `uid` was changed to `sei-slo`.
-- The default `chain_id` value `pacific-1` was removed. The dashboard now discovers chain IDs from `tendermint_consensus_latest_block_height`.
-- `chain_id="$chain_id"` selectors were changed to regex selectors so `All` and multi-chain selections work.
-- Hardcoded component labels are exposed as dashboard variables:
-  - `validator_component`, default `validators`
-  - `webapp_component`, default `webapp`
-- The public copy fixes the blocks-per-second 7-day panel to query `slo_blocks_per_second_7d`.
-
 ## Import Steps
 
 1. Add `recording_rules.yaml` to your Prometheus rule files and reload Prometheus.
@@ -27,6 +14,20 @@ The internal dashboard had a few repo-local values that should not be published 
 3. In the dashboard variables, choose your Prometheus datasource.
 4. Set `validator_component` and `webapp_component` if your Prometheus labels differ from the defaults.
 5. Select one or more `chain_id` values from the dashboard variable.
+
+No rewrite script is required for `id` or datasource UID. The dashboard has `id: null`, which lets Grafana assign the local ID at import time, and all Prometheus panels use the `datasource` dashboard variable instead of a fixed datasource UID.
+
+## Local Import Test
+
+To verify that Grafana accepts the dashboard JSON, run:
+
+```bash
+./test_import.sh
+```
+
+The script starts a disposable Grafana 12.0.0 container on `http://127.0.0.1:13000`, creates a dummy Prometheus datasource, imports `sei_slo.json`, fetches it back by UID, and prints the local dashboard URL. It does not require a running Prometheus server because the test only validates Grafana import/storage.
+
+Set `PORT=...` to use a different local port, or `KEEP_RUNNING=0` to stop Grafana after the import check.
 
 ## Required Prometheus Data
 
@@ -56,8 +57,6 @@ The included rules generate the SLO series used by the dashboard:
 - `validator_propose_latency`
 - `slo_block_miss_*`
 - `slo_validator_proposal_latency_*`
-
-The price update table depends on `slo_price_update_*{chain_id,denom}` series. Those rules were not present next to the original dashboard in this repo, so they are not included here. If you do not publish price update SLO metrics, remove or hide the "Price Update SLO" panel.
 
 ## Notes
 

--- a/sei-slo-dashboard/recording_rules.yaml
+++ b/sei-slo-dashboard/recording_rules.yaml
@@ -1,0 +1,65 @@
+groups:
+  - name: sei-slo-chain
+    rules:
+      - record: blocks_per_second
+        expr: max by (chain_id, component) (rate(tendermint_consensus_latest_block_height[5m]))
+
+      - record: slo_consensus_block_speed_30d
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[30d])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[30d]))
+      - record: slo_consensus_block_speed_14d
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[14d])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[14d]))
+      - record: slo_consensus_block_speed_7d
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[7d])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[7d]))
+      - record: slo_consensus_block_speed_24h
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[24h])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[24h]))
+      - record: slo_consensus_block_speed_12h
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[12h])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[12h]))
+      - record: slo_consensus_block_speed_6h
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[6h])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[6h]))
+      - record: slo_consensus_block_speed_1h
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[1h])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[1h]))
+      - record: slo_consensus_block_speed_30m
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[30m])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[30m]))
+      - record: slo_consensus_block_speed_5m
+        expr: sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_bucket{le="1"}[5m])) / on (chain_id, component) group_left sum by (chain_id, component) (rate(tendermint_consensus_block_interval_seconds_count[5m]))
+
+      - record: slo_blocks_per_second_30d
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[30d:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[30d:]))
+      - record: slo_blocks_per_second_14d
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[14d:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[14d:]))
+      - record: slo_blocks_per_second_7d
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[7d:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[7d:]))
+      - record: slo_blocks_per_second_24h
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[24h:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[24h:]))
+      - record: slo_blocks_per_second_12h
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[12h:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[12h:]))
+      - record: slo_blocks_per_second_6h
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[6h:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[6h:]))
+      - record: slo_blocks_per_second_1h
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[1h:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[1h:]))
+      - record: slo_blocks_per_second_30m
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[30m:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[30m:]))
+      - record: slo_blocks_per_second_5m
+        expr: sum by (chain_id, component) (sum_over_time((blocks_per_second > bool 1)[5m:])) / ignoring(chain_id, component) group_left() sum_over_time((vector(1)[5m:]))
+
+  - name: sei-slo-validator
+    rules:
+      - record: block_miss_percentage_sliding_window
+        expr: max by (moniker, chain_id, address) (cosmos_validators_missed_blocks{component="validators"}) / ignoring(moniker, address) group_left() max by (chain_id) (cosmos_params_signed_blocks_window{component="validators"})
+
+      - record: validator_propose_latency
+        expr: max by (chain_id, moniker, pubkey_hash) (cosmos_validators_active{component="webapp"}) * 0 + on(chain_id, pubkey_hash) group_left() max by(pubkey_hash, chain_id) (histogram_quantile(0.75, label_replace(tendermint_consensus_propose_latency_bucket{component="webapp"}, "pubkey_hash", "$1", "proposer_address", "(.+)")))
+
+      - record: slo_block_miss_7d
+        expr: sum by (chain_id, moniker, address) (sum_over_time((block_miss_percentage_sliding_window < bool 0.70)[7d:])) / ignoring(chain_id, moniker, address) group_left() sum_over_time((vector(1)[7d:]))
+      - record: slo_block_miss_24h
+        expr: sum by (chain_id, moniker, address) (sum_over_time((block_miss_percentage_sliding_window < bool 0.70)[24h:])) / ignoring(chain_id, moniker, address) group_left() sum_over_time((vector(1)[24h:]))
+      - record: slo_block_miss_1h
+        expr: sum by (chain_id, moniker, address) (sum_over_time((block_miss_percentage_sliding_window < bool 0.70)[1h:])) / ignoring(chain_id, moniker, address) group_left() sum_over_time((vector(1)[1h:]))
+
+      - record: slo_validator_proposal_latency_7d
+        expr: sum by (chain_id, moniker, pubkey_hash) (sum_over_time((validator_propose_latency < bool 0.5)[7d:])) / ignoring(chain_id, moniker, pubkey_hash) group_left() sum_over_time((vector(1)[7d:]))
+      - record: slo_validator_proposal_latency_24h
+        expr: sum by (chain_id, moniker, pubkey_hash) (sum_over_time((validator_propose_latency < bool 0.5)[24h:])) / ignoring(chain_id, moniker, pubkey_hash) group_left() sum_over_time((vector(1)[24h:]))
+      - record: slo_validator_proposal_latency_1h
+        expr: sum by (chain_id, moniker, pubkey_hash) (sum_over_time((validator_propose_latency < bool 0.5)[1h:])) / ignoring(chain_id, moniker, pubkey_hash) group_left() sum_over_time((vector(1)[1h:]))

--- a/sei-slo-dashboard/sei_slo.json
+++ b/sei-slo-dashboard/sei_slo.json
@@ -918,7 +918,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max by (moniker, pubkey_hash) (validator_propose_latency)",
+          "expr": "max by (moniker, pubkey_hash) (validator_propose_latency{chain_id=~\"$chain_id\"})",
           "interval": "15m",
           "legendFormat": "{{moniker}}",
           "range": true,
@@ -1020,7 +1020,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max by (moniker, address) (block_miss_percentage_sliding_window)",
+          "expr": "max by (moniker, address) (block_miss_percentage_sliding_window{chain_id=~\"$chain_id\"})",
           "interval": "15m",
           "legendFormat": "{{moniker}}",
           "range": true,
@@ -1122,7 +1122,7 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "max by (moniker) (cosmos_validators_jailed{component=\"$webapp_component\"}) > 0",
+          "expr": "max by (moniker) (cosmos_validators_jailed{chain_id=~\"$chain_id\", component=\"$webapp_component\"}) > 0",
           "interval": "15m",
           "legendFormat": "{{moniker}}",
           "range": true,

--- a/sei-slo-dashboard/sei_slo.json
+++ b/sei-slo-dashboard/sei_slo.json
@@ -814,404 +814,12 @@
       "type": "bargauge"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
-      "description": "1.0 = 60% of blocks updates the price for the denom",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "continuous-BlPu"
-          },
-          "custom": {
-            "align": "auto",
-            "cellOptions": {
-              "type": "auto"
-            },
-            "inspect": false
-          },
-          "mappings": [],
-          "max": 1,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "percentunit"
-        },
-        "overrides": [
-          {
-            "matcher": {
-              "id": "byRegexp",
-              "options": "chain_id.*"
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Time"
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "__name__"
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #5m"
-            },
-            "properties": [
-              {
-                "id": "displayName",
-                "value": "5 mins"
-              },
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #30m"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "30 mins"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #1h"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "1 hour"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #12h"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "12 hours"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #24h"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "24 hours"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #14d"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "14 days"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #30d"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "30 days"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "Value #7d"
-            },
-            "properties": [
-              {
-                "id": "custom.cellOptions",
-                "value": {
-                  "mode": "gradient",
-                  "type": "gauge"
-                }
-              },
-              {
-                "id": "displayName",
-                "value": "7 days"
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "component"
-            },
-            "properties": [
-              {
-                "id": "custom.hidden",
-                "value": true
-              }
-            ]
-          }
-        ]
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 21
-      },
-      "id": 20,
-      "options": {
-        "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
-        "showHeader": true,
-        "sortBy": []
-      },
-      "pluginVersion": "12.0.0",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max by (denom) (slo_price_update_5m{chain_id=~\"$chain_id\"})",
-          "format": "table",
-          "instant": true,
-          "legendFormat": "5min",
-          "range": false,
-          "refId": "5m"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max by (denom) (slo_price_update_30m{chain_id=~\"$chain_id\"})",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "30m",
-          "range": false,
-          "refId": "30m"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max by (denom) (slo_price_update_1h{chain_id=~\"$chain_id\"})",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "1h",
-          "range": false,
-          "refId": "1h"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "max by (denom) (slo_price_update_12h{chain_id=~\"$chain_id\"})",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "12h",
-          "range": false,
-          "refId": "12h"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "slo_price_update_24h{chain_id=~\"$chain_id\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "24h",
-          "range": false,
-          "refId": "24h"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "slo_price_update_7d{chain_id=~\"$chain_id\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "__auto",
-          "range": false,
-          "refId": "7d"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "slo_price_update_14d{chain_id=~\"$chain_id\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "14d",
-          "range": false,
-          "refId": "14d"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "exemplar": false,
-          "expr": "slo_price_update_30d{chain_id=~\"$chain_id\"}",
-          "format": "table",
-          "hide": false,
-          "instant": true,
-          "legendFormat": "30d",
-          "range": false,
-          "refId": "30d"
-        }
-      ],
-      "title": "Price Update SLO ",
-      "transformations": [
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "denom",
-            "mode": "outer"
-          }
-        }
-      ],
-      "type": "table"
-    },
-    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 21
       },
       "id": 23,
       "panels": [],
@@ -1283,7 +891,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 30
+        "y": 22
       },
       "id": 24,
       "options": {
@@ -1385,7 +993,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 30
+        "y": 22
       },
       "id": 25,
       "options": {
@@ -1487,7 +1095,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 30
       },
       "id": 27,
       "options": {
@@ -1530,7 +1138,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 38
       },
       "id": 6,
       "panels": [],
@@ -1648,7 +1256,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 39
       },
       "id": 13,
       "options": {
@@ -1833,7 +1441,7 @@
         "h": 11,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 39
       },
       "id": 11,
       "options": {

--- a/sei-slo-dashboard/sei_slo.json
+++ b/sei-slo-dashboard/sei_slo.json
@@ -1,0 +1,2019 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 2,
+  "id": null,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 15,
+      "panels": [],
+      "title": "Raw Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Block Height"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlPu"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 19,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max(tendermint_consensus_latest_block_height{chain_id=~\"$chain_id\"})",
+          "format": "time_series",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "Block Height",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Chain Height",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 0,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "number"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlPu"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p50 block time"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Blocks Per Second"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 7,
+        "x": 3,
+        "y": 1
+      },
+      "id": 17,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, sum(rate(tendermint_consensus_block_interval_seconds_bucket{chain_id=~\"$chain_id\"}[5m])) by (le)) ",
+          "interval": "1m",
+          "legendFormat": "p50 block time",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "min(blocks_per_second{chain_id=~\"$chain_id\", component=\"$validator_component\"})",
+          "hide": false,
+          "interval": "1m",
+          "legendFormat": "Blocks Per Second",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Block Performance",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 0,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byType",
+              "options": "number"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "mode": "continuous-BlPu",
+                  "seriesBy": "max"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Transactions per sec"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Messages Per Sec"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Orders Per Sec"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 7,
+        "x": 17,
+        "y": 1
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(sei_cosmos_throughput_transaction_count{chain_id=~\"$chain_id\", component=\"$validator_component\", mode=\"deliver\"}[5m]))",
+          "hide": false,
+          "legendFormat": "Transactions per sec",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max(rate(sei_cosmos_throughput_message_count{chain_id=~\"$chain_id\", component=\"$validator_component\"}[5m]))",
+          "hide": false,
+          "legendFormat": "Messages Per Sec",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Throughput Per Second",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 4,
+      "panels": [],
+      "title": "Chain Level",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "1.0 = 100% of blocks are produced within 1 second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "id": 2,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_5m{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "legendFormat": "5 mins",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_30m{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "30 mins",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_1h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "1 hour",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_6h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "6 hours",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_12h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "12 hours",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_24h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "24 hours",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_7d{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "7 days",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_14d{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "14 days",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_consensus_block_speed_30d{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "30 days",
+          "range": true,
+          "refId": "I"
+        }
+      ],
+      "title": "Chain Performance SLO ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "1.0 = 100% of the time interval is producing at least 1 block per second",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "id": 7,
+      "options": {
+        "displayMode": "gradient",
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": false
+        },
+        "maxVizHeight": 300,
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_5m{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "legendFormat": "5 mins",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_30m{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "30 mins",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_1h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "1 hour",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_6h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "6 hours",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_12h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "12 hours",
+          "range": true,
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_24h{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "24 hours",
+          "range": true,
+          "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_7d{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "7 days",
+          "range": true,
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_14d{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "14 days",
+          "range": true,
+          "refId": "H"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "slo_blocks_per_second_30d{chain_id=~\"$chain_id\", component=\"$validator_component\"}",
+          "hide": false,
+          "legendFormat": "30 days",
+          "range": true,
+          "refId": "I"
+        }
+      ],
+      "title": "Chain Uptime SLO ",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "1.0 = 60% of blocks updates the price for the denom",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "chain_id.*"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "__name__"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #5m"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "5 mins"
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #30m"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "30 mins"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #1h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "1 hour"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #12h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "12 hours"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #24h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "24 hours"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #14d"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "14 days"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #30d"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "30 days"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #7d"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "7 days"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "component"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 20,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (denom) (slo_price_update_5m{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "5min",
+          "range": false,
+          "refId": "5m"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (denom) (slo_price_update_30m{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "30m",
+          "range": false,
+          "refId": "30m"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (denom) (slo_price_update_1h{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "1h",
+          "range": false,
+          "refId": "1h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (denom) (slo_price_update_12h{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "12h",
+          "range": false,
+          "refId": "12h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "slo_price_update_24h{chain_id=~\"$chain_id\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "24h",
+          "range": false,
+          "refId": "24h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "slo_price_update_7d{chain_id=~\"$chain_id\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "7d"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "slo_price_update_14d{chain_id=~\"$chain_id\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "14d",
+          "range": false,
+          "refId": "14d"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "slo_price_update_30d{chain_id=~\"$chain_id\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "30d",
+          "range": false,
+          "refId": "30d"
+        }
+      ],
+      "title": "Price Update SLO ",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "denom",
+            "mode": "outer"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 29
+      },
+      "id": 23,
+      "panels": [],
+      "title": "Raw Metrics (Validator)",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "Raw metrics for validator proposal latency (in seconds)\n\nTendermint Metric:\ntendermint_consensus_propose_latency_bucket\n\nrecord:validator_propose_latency\nexpr:max by (chain_id, moniker, pubkey_hash) (cosmos_validators_active{component=\"$validator_component\"} > 0) * 0 + on (chain_id, pubkey_hash) group_left () max by (pubkey_hash, chain_id) (histogram_quantile(0.75, label_replace(tendermint_consensus_propose_latency_bucket{component=\"$validator_component\"}, \"pubkey_hash\", \"$1\", \"proposer_address\", \"(.+)\")))",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (moniker, pubkey_hash) (validator_propose_latency)",
+          "interval": "15m",
+          "legendFormat": "{{moniker}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Validator Performance ",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "> 95% to get jailed\n\n\nrecord:block_miss_percentage_sliding_window\nexpr:max by (moniker, chain_id, address) (cosmos_validators_missed_blocks{component=\"$validator_component\"}) / ignoring (moniker, address) group_left () max by (chain_id) (cosmos_params_signed_blocks_window{component=\"$validator_component\"})\nCosmos Level Metrics:\ncosmos_validators_missed_blocks",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (moniker, address) (block_miss_percentage_sliding_window)",
+          "interval": "15m",
+          "legendFormat": "{{moniker}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Validator Block Misses",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "max by (moniker) (cosmos_validators_jailed{component=\"$webapp_component\"}) > 0",
+          "interval": "15m",
+          "legendFormat": "{{moniker}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Validators Jailed",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Validator Level",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "1.0 = 100% of the time the validator sent in proposals under 500ms",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #7d"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "7 Days"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #24h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "24 Hours"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #1h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "1 Hour"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 47
+      },
+      "id": 13,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (moniker) (slo_validator_proposal_latency_1h{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "1h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (moniker) (slo_validator_proposal_latency_24h{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "24h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (moniker) (slo_validator_proposal_latency_7d{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "7d"
+        }
+      ],
+      "title": "Validator Performance SLO",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "moniker",
+            "mode": "outer"
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "1.0 = 100% of the time the validator is missing more than 70% of the blocks in the time period",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #7d"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "7 Days"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #24h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "24 Hours"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value #1h"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "mode": "gradient",
+                  "type": "gauge"
+                }
+              },
+              {
+                "id": "displayName",
+                "value": "1 Hour"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 47
+      },
+      "id": 11,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "12.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (moniker) (slo_block_miss_1h{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "1h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (moniker) (slo_block_miss_24h{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "24h"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "max by (moniker) (slo_block_miss_7d{chain_id=~\"$chain_id\"})",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "7d"
+        }
+      ],
+      "title": "Validator Uptime SLO",
+      "transformations": [
+        {
+          "id": "joinByField",
+          "options": {
+            "byField": "moniker",
+            "mode": "outer"
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "preload": false,
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": [
+    "SLO"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Prometheus datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "validators",
+          "value": "validators"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Validator component label",
+        "multi": false,
+        "name": "validator_component",
+        "options": [
+          {
+            "selected": true,
+            "text": "validators",
+            "value": "validators"
+          }
+        ],
+        "query": "validators",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "webapp",
+          "value": "webapp"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Validator metadata component label",
+        "multi": false,
+        "name": "webapp_component",
+        "options": [
+          {
+            "selected": true,
+            "text": "webapp",
+            "value": "webapp"
+          }
+        ],
+        "query": "webapp",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "$datasource"
+        },
+        "definition": "label_values(tendermint_consensus_latest_block_height, chain_id)",
+        "includeAll": true,
+        "label": "Chain ID",
+        "name": "chain_id",
+        "options": [],
+        "query": {
+          "query": "label_values(tendermint_consensus_latest_block_height, chain_id)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "type": "query",
+        "allValue": ".*",
+        "multi": true
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Sei SLO",
+  "uid": "sei-slo",
+  "version": 1
+}

--- a/sei-slo-dashboard/sei_slo.json
+++ b/sei-slo-dashboard/sei_slo.json
@@ -1335,7 +1335,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "1.0 = 100% of the time the validator is missing more than 70% of the blocks in the time period",
+      "description": "1.0 = 100% of the time the validator missed less than 70% of blocks in the time period",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/sei-slo-dashboard/test_import.sh
+++ b/sei-slo-dashboard/test_import.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+CONTAINER_NAME="${CONTAINER_NAME:-sei-slo-grafana-import-test}"
+GRAFANA_IMAGE="${GRAFANA_IMAGE:-grafana/grafana:12.0.0}"
+PORT="${PORT:-13000}"
+GRAFANA_URL="http://127.0.0.1:${PORT}"
+ADMIN_USER="${ADMIN_USER:-admin}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-admin}"
+KEEP_RUNNING="${KEEP_RUNNING:-1}"
+
+for binary in docker curl jq; do
+  if ! command -v "${binary}" >/dev/null 2>&1; then
+    echo "missing required command: ${binary}" >&2
+    exit 1
+  fi
+done
+
+if docker ps -a --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"; then
+  docker rm -f "${CONTAINER_NAME}" >/dev/null
+fi
+
+docker run -d --rm \
+  --name "${CONTAINER_NAME}" \
+  -p "${PORT}:3000" \
+  -e "GF_SECURITY_ADMIN_USER=${ADMIN_USER}" \
+  -e "GF_SECURITY_ADMIN_PASSWORD=${ADMIN_PASSWORD}" \
+  -e GF_AUTH_ANONYMOUS_ENABLED=false \
+  "${GRAFANA_IMAGE}" >/dev/null
+
+echo "waiting for Grafana at ${GRAFANA_URL}"
+for _ in $(seq 1 60); do
+  if curl -fsS -u "${ADMIN_USER}:${ADMIN_PASSWORD}" "${GRAFANA_URL}/api/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+curl -fsS -u "${ADMIN_USER}:${ADMIN_PASSWORD}" \
+  -H 'Content-Type: application/json' \
+  -X POST "${GRAFANA_URL}/api/datasources" \
+  -d '{"name":"Prometheus","uid":"Prometheus","type":"prometheus","access":"proxy","url":"http://prometheus:9090","isDefault":true,"jsonData":{"timeInterval":"15s"}}' >/dev/null
+
+payload="$(mktemp)"
+trap 'rm -f "${payload}"' EXIT
+jq -c '{dashboard: ., overwrite: true, folderId: 0}' "${SCRIPT_DIR}/sei_slo.json" > "${payload}"
+
+import_response="$(
+  curl -fsS -u "${ADMIN_USER}:${ADMIN_PASSWORD}" \
+    -H 'Content-Type: application/json' \
+    -X POST "${GRAFANA_URL}/api/dashboards/db" \
+    --data-binary @"${payload}"
+)"
+
+status="$(printf '%s' "${import_response}" | jq -r '.status')"
+if [[ "${status}" != "success" ]]; then
+  echo "dashboard import failed: ${import_response}" >&2
+  exit 1
+fi
+
+curl -fsS -u "${ADMIN_USER}:${ADMIN_PASSWORD}" \
+  "${GRAFANA_URL}/api/dashboards/uid/sei-slo" \
+  | jq -r '"imported \(.dashboard.title) uid=\(.dashboard.uid) id=\(.dashboard.id) panels=\(.dashboard.panels | length)"'
+
+echo "dashboard URL: ${GRAFANA_URL}/d/sei-slo/sei-slo"
+
+if [[ "${KEEP_RUNNING}" == "0" ]]; then
+  docker stop "${CONTAINER_NAME}" >/dev/null
+  echo "stopped ${CONTAINER_NAME}"
+else
+  echo "stop with: docker stop ${CONTAINER_NAME}"
+fi


### PR DESCRIPTION
Add Sei SLO dashboard to public repo, as well as a local test
Tested with local docker
<img width="1922" height="926" alt="image" src="https://github.com/user-attachments/assets/2e6b893f-6946-46d4-957a-f907f8b7fde0" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because the PR is purely additive (dashboard JSON, Prometheus recording rules, and docs) and does not modify runtime application code or security-sensitive logic.
> 
> **Overview**
> Adds a new `sei-slo-dashboard/` bundle that operators can import into Grafana, including the `sei_slo.json` dashboard and required `recording_rules.yaml` to compute chain- and validator-level SLO series.
> 
> Includes `test_import.sh`, which spins up a disposable Grafana container, creates a dummy Prometheus datasource, imports the dashboard, and verifies it can be fetched back by UID; `README.md` documents required metrics/labels and import steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3063f7b0849cb7384387d925093d6342e8ebfa85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->